### PR TITLE
Updated multiple files to support an additional region

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,9 @@ Requires:
 
 This software is open sourced by Ping Identity but not supported commercially as such. Any questions/issues should go to the Github issues tracker or discuss on the [Ping Identity developer communities] . See also the DISCLAIMER file in this directory.
 
+### Comments
+The Get-PingID-Reports.ps1 is best copied into the ./scripts folder and then run from that locations.
+The script contains multiple references to files local to ./scripts folder
+
 [Ping Identity developer communities]: https://community.pingidentity.com/collaborate
 [Ping Identity Developer Site]: https://developer.pingidentity.com/connect

--- a/scripts/Activate-User.ps1
+++ b/scripts/Activate-User.ps1
@@ -33,7 +33,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/activateuser/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/activateuser/do"
+ $apiEndpoint = $($localPingID +"activateuser/do")
 
 $reqBody = @{
 	"userName" = $UserName
@@ -43,7 +44,9 @@ $responsePayload = Call-PingID-API $reqBody $apiEndpoint
 
 
 #	Retrieve the User Details to verify call
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+ $userDetailsEndpoint = $($localPingID +"getuserdetails/do")
+
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Add-User.ps1
+++ b/scripts/Add-User.ps1
@@ -55,13 +55,14 @@ param(
 	[string]$Role = "REGULAR"
 )
 
-
 #	Import PingID API helper functions
 . .\pingid-api-helper.ps1
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/adduser/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/adduser/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.eu/pingid/rest/4/adduser/do"
+ $apiEndpoint = $($localPingID +"adduser/do")
 
 $reqBody = @{
 	"userName" = $UserName
@@ -76,7 +77,9 @@ $responsePayload = Call-PingID-API $reqBody $apiEndpoint
 
 
 #	Retrieve the User Details to verify call
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+ $userDetailsEndpoint = $($localPingID +"getuserdetails/do")
+
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Create-Job.ps1
+++ b/scripts/Create-Job.ps1
@@ -32,7 +32,9 @@ param(
 
 
 #	Create the API request and parse the results.
-$createJobEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/createjob/do"
+#$createJobEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/createjob/do"
+ $createJobEndpoint = $($localPingID +"createjob/do")
+
 $createJobBody = @{
 	"jobType" = $JobType
 }

--- a/scripts/Delete-User.ps1
+++ b/scripts/Delete-User.ps1
@@ -33,7 +33,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/deleteuser/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/deleteuser/do"
+ $apiEndpoint = $($localPingID +"deleteuser/do")
 
 $reqBody = @{
 	"userName" = $UserName
@@ -43,7 +44,8 @@ $responsePayload = Call-PingID-API $reqBody $apiEndpoint
 
 
 #	Retrieve the User Details to verify call
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+ $userDetailsEndpoint = $($localPingID +"getuserdetails/do")
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Do-Offline-Pairing.ps1
+++ b/scripts/Do-Offline-Pairing.ps1
@@ -41,7 +41,10 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/offlinepairing/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/offlinepairing/do"
+ $apiEndpoint = $($localPingID +"offlinepairing/do")
+
+
 
 $reqBody = @{
 	"username" = $UserName

--- a/scripts/Edit-User.ps1
+++ b/scripts/Edit-User.ps1
@@ -61,7 +61,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/edituser/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/edituser/do"
+ $apiEndpoint = $($localPingID +"edituser/do")
 
 $reqBody = @{
 	"userName" = $UserName
@@ -76,7 +77,8 @@ $responsePayload = Call-PingID-API $reqBody $apiEndpoint
 
 
 #	Retrieve the User Details to verify call
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+$userDetailsEndpoint = $($localPingID +"getuserdetails/do")
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Finalize-Offline-Pairing.ps1
+++ b/scripts/Finalize-Offline-Pairing.ps1
@@ -39,7 +39,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/finalizeofflinepairing/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/finalizeofflinepairing/do"
+ $apiEndpoint = $($localPingID +"finalizeofflinepairing/do")
 
 $reqBody = @{
 	"sessionId" = $SessionId

--- a/scripts/Get-Activation-Code.ps1
+++ b/scripts/Get-Activation-Code.ps1
@@ -33,7 +33,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getactivationcode/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getactivationcode/do"
+ $apiEndpoint = $($localPingID +"getactivationcode/do")
 
 $reqBody = @{
 	"userName" = $UserName

--- a/scripts/Get-Job-Status.ps1
+++ b/scripts/Get-Job-Status.ps1
@@ -33,7 +33,9 @@ param(
 
 
 #	Create the API request and parse the results.
-$getJobStatusEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getjobstatus/do"
+#$getJobStatusEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getjobstatus/do"
+ $getJobStatusEndpoint = $($localPingID +"getjobstatus/do")
+
 $getJobStatusBody = @{
 	"jobToken" = $JobToken
 }

--- a/scripts/Get-Organization-Report.ps1
+++ b/scripts/Get-Organization-Report.ps1
@@ -32,7 +32,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$orgReportEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getorgreport/do"
+#$orgReportEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getorgreport/do"
+ $orgReportEndpoint = $($localPingID +"getorgreport/do")
 $orgReportBody = @{
 	"fileType" = $FileType
 }

--- a/scripts/Get-Pairing-Status.ps1
+++ b/scripts/Get-Pairing-Status.ps1
@@ -33,7 +33,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/pairingstatus/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/pairingstatus/do"
+ $apiEndpoint = $($localPingID +"pairingstatus/do")
 
 $reqBody = @{
 	"activationCode" = $ActivationCode

--- a/scripts/Get-User-Details.ps1
+++ b/scripts/Get-User-Details.ps1
@@ -33,7 +33,9 @@ param(
 
 
 #	Create the API request and parse the results.
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+ $userDetailsEndpoint = $($localPingID +"getuserdetails/do")
+
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Pair-YubiKey.ps1
+++ b/scripts/Pair-YubiKey.ps1
@@ -39,7 +39,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/pairyubikey/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/pairyubikey/do"
+ $apiEndpoint = $($localPingID +"pairyubikey/do")
 
 $reqBody = @{
 	"username" = $UserName
@@ -49,7 +50,8 @@ $reqBody = @{
 $responsePayload = Call-PingID-API $reqBody $apiEndpoint
 
 #	Retrieve the User Details to verify call
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+ $userDetailsEndpoint = $($localPingID +"getuserdetails/do")
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Start-Offline-Pairing.ps1
+++ b/scripts/Start-Offline-Pairing.ps1
@@ -45,7 +45,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/startofflinepairing/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/startofflinepairing/do"
+ $apiEndpoint = $($localPingID +"startofflinepairing/do")
 
 $reqBody = @{
 	"username" = $UserName

--- a/scripts/Suspend-User.ps1
+++ b/scripts/Suspend-User.ps1
@@ -33,7 +33,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/suspenduser/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/suspenduser/do"
+ $apiEndpoint = $($localPingID +"suspenduser/do")
 
 $reqBody = @{
 	"userName" = $UserName
@@ -43,7 +44,8 @@ $responsePayload = Call-PingID-API $reqBody $apiEndpoint
 
 
 #	Retrieve the User Details to verify call
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+ $userDetailsEndpoint = $($localPingID +"getuserdetails/do")
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Toggle-User-Bypass.ps1
+++ b/scripts/Toggle-User-Bypass.ps1
@@ -42,13 +42,14 @@ param(
 	[int]$Minutes = 0
 )
 
-
 #	Import PingID API helper functions
 . .\pingid-api-helper.ps1
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/userbypass/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/userbypass/do"
+ $apiEndpoint = $($localPingID +"userbypass/do")
+
 $secondsToBypass = ($Minutes * 60) + ($Hours * 3600) + ($Days * 86400)
 
 if ($secondsToBypass -eq 0) {
@@ -70,7 +71,8 @@ $responsePayload = Call-PingID-API $reqBody $apiEndpoint
 
 
 #	Retrieve the User Details to verify call
-$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+#$userDetailsEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+ $userDetailsEndpoint = $($localPingID +"getuserdetails/do")
 $userDetailsBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false

--- a/scripts/Unpair-Device.ps1
+++ b/scripts/Unpair-Device.ps1
@@ -33,7 +33,8 @@ param(
 
 
 #	Create the API request and parse the results.
-$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/unpairdevice/do"
+#$apiEndpoint = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/unpairdevice/do"
+ $apiEndpoint = $($localPingID +"unpairdevice/do")
 
 $reqBody = @{
 	"userName" = $UserName
@@ -47,5 +48,7 @@ $reqBody = @{
 	"userName" = $UserName
 	"getSameDeviceUsers" = $false
 }
-$responsePayload = Call-PingID-API $reqBody "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getuserdetails/do"
+$userDetailsEndpoint = $($localPingID +"getuserdetails/do")
+$responsePayload = Call-PingID-API $reqBody $userDetailsEndpoint
+
 Write-Output $responsePayload

--- a/scripts/pingid-api-helper.ps1
+++ b/scripts/pingid-api-helper.ps1
@@ -13,9 +13,25 @@
 #	Replace with the PingID settings found in the PingID settings file:
 #   Note: Remove any backslash characters from the use_base64_key value.
 
-$org_alias      = "<< orgAlias value from pingid.properties file >>";
-$use_base64_key = "<< use_base64_key value from pingid.properties file >>";
-$token          = "<< token value from pingid.properties file >>";
+#$localRegion   = "eu"
+ $localRegion   = "com"
+
+if ($localRegion -eq "com") {
+	# -- US Region--
+	$org_alias      = "US-Org-Alias";
+	$use_base64_key = "US-base64-key";
+	$token          = "US-token-value";
+} elseIf ($localRegion -eq "eu"){
+	# -- EU Region --
+	$org_alias      = "EU-Org-Alias";
+	$use_base64_key = "EU-base64-key";
+	$token          = "EU-token-value";
+}
+
+#$localPingID   = "https://idpxnyl3m.pingidentity.eu/pingid/rest/4/"
+#$localPingID   = "https://idpxnyl3m.pingidentity.com/pingid/rest/4/"
+$localPingID    = $("https://idpxnyl3m.pingidentity." + $localRegion + "/pingid/rest/4/")
+$logLocation    = "C:\media\Ping\logs"
 $api_version    = "4.9"
 
 function Convert-StringToByteArray {
@@ -151,7 +167,7 @@ function Call-PingID-API {
 	try {
 	    if ($apiEndpoint -eq "https://idpxnyl3m.pingidentity.com/pingid/rest/4/getorgreport/do") {
             $logTimeStamp = Get-Date -f yyyyMMddHHmmss
-    	    $apiResponse = Invoke-WebRequest -Uri $apiEndpoint -Body $apiToken -ContentType "application/json" -Method Post -Outfile E:\pingid-users\pingid-$logTimeStamp.$fileType
+    	    $apiResponse = Invoke-WebRequest -Uri $apiEndpoint -Body $apiToken -ContentType "application/json" -Method Post -Outfile $($logLocation + "\pingid-$logTimeStamp.$fileType")
         } else {
 		    $apiResponse = Invoke-WebRequest -Uri $apiEndpoint -Body $apiToken -ContentType "application/json" -Method Post
 		}


### PR DESCRIPTION
The default set of files was written to support the default PingID US Region ".com".
Each user that owned a non-US PingID Regious would have to modify each file to make changes
to support the region.

I have made the required changes for the default page to support "another Region" by modifying the following:-
a. Modifying the helper script: pingid-api-helper.ps1 with a few changes:-
    a.1 Creation of a "Region" variable
    a.2 Create a switch for the "Region" Variable
    a.3 Create a new PingID base URL containing the region, that requires the appending of the required function
b. For each of the PingID PowerShell Scripts, modify the default URL to use the new Base URL + function 